### PR TITLE
Update ruby snippets - correct class and module names

### DIFF
--- a/snippets/ruby.snippets
+++ b/snippets/ruby.snippets
@@ -60,11 +60,11 @@ snippet until
 		${2}
 	end
 snippet cla class .. end
-	class ${1:`substitute(Filename(), '^.', '\u&', '')`}
+	class ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`}
 		${2}
 	end
 snippet cla class .. initialize .. end
-	class ${1:`substitute(Filename(), '^.', '\u&', '')`}
+	class ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`}
 		def initialize(${2:args})
 			${3}
 		end
@@ -72,7 +72,7 @@ snippet cla class .. initialize .. end
 
 	end
 snippet cla class .. < ParentClass .. initialize .. end
-	class ${1:`substitute(Filename(), '^.', '\u&', '')`} < ${2:ParentClass}
+	class ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`} < ${2:ParentClass}
 		def initialize(${3:args})
 			${4}
 		end
@@ -80,7 +80,7 @@ snippet cla class .. < ParentClass .. initialize .. end
 
 	end
 snippet cla ClassName = Struct .. do .. end
-	${1:`substitute(Filename(), '^.', '\u&', '')`} = Struct.new(:${2:attr_names}) do
+	${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`} = Struct.new(:${2:attr_names}) do
 		def ${3:method_name}
 			${4}
 		end
@@ -96,7 +96,7 @@ snippet cla class << self .. end
 	end
 # class .. < DelegateClass .. initialize .. end
 snippet cla-
-	class ${1:`substitute(Filename(), '^.', '\u&', '')`} < DelegateClass(${2:ParentClass})
+	class ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`} < DelegateClass(${2:ParentClass})
 		def initialize(${3:args})
 			super(${4:del_obj})
 
@@ -106,17 +106,17 @@ snippet cla-
 
 	end
 snippet mod module .. end
-	module ${1:`substitute(Filename(), '^.', '\u&', '')`}
+	module ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`}
 		${2}
 	end
 snippet mod module .. module_function .. end
-	module ${1:`substitute(Filename(), '^.', '\u&', '')`}
+	module ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`}
 		module_function
 
 		${2}
 	end
 snippet mod module .. ClassMethods .. end
-	module ${1:`substitute(Filename(), '^.', '\u&', '')`}
+	module ${1:`substitute(substitute(Filename(), '^.', '\u&', ''), '_\(.\)', '\U\1', 'g')`}
 		module ClassMethods
 			${2}
 		end


### PR DESCRIPTION
This update ensure that snake_cased ruby filenames are properly changed into CamelCaps casing for ruby class and module snippets

Feel free to test this before merging. I have been using this change for a while now, but it's always important to have someone else double check me...
